### PR TITLE
fix: Resolve Responsive Issue on Certain Screen Sizes (#5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27217,6 +27217,21 @@
         "ts-toolbelt": "^9.6.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/typical": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-7.1.1.tgz",

--- a/src/core/components/responses.jsx
+++ b/src/core/components/responses.jsx
@@ -96,6 +96,7 @@ export default class Responses extends React.Component {
           <h4>Responses</h4>
             { specSelectors.isOAS3() ? null : <label htmlFor={controlId}>
               <span>Response content type</span>
+           
               <ContentType value={producesValue}
                          ariaControls={regionId}
                          ariaLabel="Response content type"

--- a/src/style/_layout.scss
+++ b/src/style/_layout.scss
@@ -266,48 +266,72 @@
         }
     }
 
-    .opblock-section-header
-    {
+    .opblock-section-header {
         display: flex;
+        flex-wrap: wrap;        // Allow elements to wrap when screen space is limited
         align-items: center;
-
         padding: 8px 20px;
-
         min-height: 50px;
+        background: rgba($opblock-isopen-section-header-background-color, .8);
+        box-shadow: 0 1px 2px rgba($opblock-isopen-section-header-box-shadow-color, .1);
+      
+        h4 {
+          font-size: 14px;      // Font size in pixels
+          flex: 1;
+          margin: 0;
+      
+          @include text_headline();
+        }
+      
+        label {
+          font-size: 12px;      // Font size in pixels
+          font-weight: bold;
+          display: flex;
+          align-items: center;
+          margin-left: auto;    // Push to the right when there is space
+          margin-top: 10px;     // Add margin for spacing when elements wrap
+      
+          > span {
+            padding: 0 10px 0 0;
+          }
+          @media (max-width: 1024px) and (min-width: 768px) {
+            flex-direction: column;
+            gap:10px;
+            align-items: flex-start;
+          }
 
-        background: rgba($opblock-isopen-section-header-background-color,.8);
-        box-shadow: 0 1px 2px rgba($opblock-isopen-section-header-box-shadow-color,.1);
-
-        >label
-        {
-            font-size: 12px;
-            font-weight: bold;
-
-            display: flex;
-            align-items: center;
-
-            margin: 0;
-            margin-left: auto;
-
-            @include text_headline();
-
-            >span
-            {
-                padding: 0 10px 0 0;
-            }
+        }
+      
+        // Make the select (ContentType component) responsive
+     select {
+          width: 100%;               // Full width in the container
+          max-width: 300px;          // Limit maximum width
+          padding: 8px;
+          font-size: 12px;           // Font size in pixels
+          border-radius: 5px;        // Border radius in pixels
+          box-sizing: border-box;
+          @media (max-width: 1024px) and (min-width: 768px) {
+            max-width: 200px;  
+            display: block;      // Reduce max-width for medium-sized screens
+            font-size: 11px;         // Slightly smaller font size
+            padding: 8px;            // Reduced padding for smaller screens
+          }
+          @media (max-width: 768px) {
+            max-width: 80%;        // Use full width on smaller screens
+          }
+      
+          @media (max-width: 480px) {
+            font-size: 10px;
+          
+          }
         }
 
-        h4
-        {
-            font-size: 14px;
-
-            flex: 1;
-
-            margin: 0;
-
-            @include text_headline();
-        }
-    }
+        @media (max-width: 1024px) and (min-width: 768px) {
+            gap:10px;
+          }
+       
+      }
+      
 
     .opblock-summary-method
     {
@@ -904,6 +928,7 @@
         }
     }
 }
+
 
 .loading-container
 {


### PR DESCRIPTION
🐞 Bug Fix for Issue #5
This PR addresses the responsive display issues outlined in [#5](https://github.com/Swaggy-Swagger/swaggy-ui/compare/master...Jeevan-Neupane:swaggy-ui:bug/responsive-issue-5?expand=1#5), where certain elements were misaligned or not rendering correctly on specific screen sizes.

Changes Made
Adjusted media queries to handle breakpoints more effectively between 1024px and 780px.
Updated the CSS for improved responsiveness of the select element and other layout components.
Tested and verified

 the fix across a range of devices to ensure consistent UI performance.
Screenshots (Before & After)
Before 
<img width="922" alt="before" src="https://github.com/user-attachments/assets/cb4e3a11-01ce-47b9-9869-b65e2168aa75">

After
![Screenshot 2024-10-27 205427](https://github.com/user-attachments/assets/80d1cf88-ba05-45b7-b7a9-ebb7836099cc)


Testing Instructions
Resize the browser window to screen sizes between 1024px and 780px.
Verify that all elements, particularly the select dropdown, are rendering correctly.
Check the page layout for any misalignment or broken styles.
Related Issue
[#5](https://github.com/Swaggy-Swagger/swaggy-ui/compare/master...Jeevan-Neupane:swaggy-ui:bug/responsive-issue-5?expand=1#5) - [BUG] Responsive issue on Certain screen sizes
Checklist
 Fixes the identified bug for screen sizes between 1024px and 780px.
 Tested on different devices and browsers for consistent behavior.
 Code follows the project’s coding standards.
Let me know if you have any questions or need further adjustments!